### PR TITLE
moved assert.that() .is & .not into prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,21 @@ assert.that(actual).is.undefined();
 assert.that(actual).is.not.undefined();
 ```
 
+### existing
+
+Assert that `actual` exists
+```javascript
+assert.that(actual).is.existing();
+assert.that(actual).is.not.existing();
+```
+
+### array
+
+Assert that `actual` is an array
+```javascript
+assert.that(actual).is.array();
+```
+
 ## Running the build
 
 This module can be built using [Grunt](http://gruntjs.com/). Besides running the tests, this also analyses the code. To run Grunt, go to the folder where you have installed assertthat and run `grunt`. You need to have [grunt-cli](https://github.com/gruntjs/grunt-cli) installed.

--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -20,59 +20,73 @@ var atLeast = require('./constraints/atLeast'),
     startingWith = require('./constraints/startingWith'),
     throwing = require('./constraints/throwing');
 
-var assert = {};
+var Not = function() {}
+Not.prototype.atLeast            = function(actual){ return atLeast.negated(actual) };
+Not.prototype.atMost             = function(actual){ return atMost.negated(actual) };
+Not.prototype.between            = function(actual){ return between.negated(actual) };
+Not.prototype.containing         = function(actual){ return containing.negated(actual) };
+Not.prototype.endingWith         = function(actual){ return endingWith.negated(actual) };
+Not.prototype.equalTo            = function(actual){ return equalTo.negated(actual) };
+Not.prototype.false              = function(actual){ return isFalse.negated(actual) };
+Not.prototype.falsy              = function(actual){ return falsy.negated(actual) };
+Not.prototype.greaterThan        = function(actual){ return greaterThan.negated(actual) };
+Not.prototype.instanceOf         = function(actual){ return instanceOf.negated(actual) };
+Not.prototype.lessThan           = function(actual){ return lessThan.negated(actual) };
+Not.prototype.NaN                = function(actual){ return isNan.negated(actual) };
+Not.prototype.null               = function(actual){ return isNull.negated(actual) };
+Not.prototype.ofType             = function(actual){ return ofType.negated(actual) };
+Not.prototype.sameAs             = function(actual){ return sameAs.negated(actual) };
+Not.prototype.startingWith       = function(actual){ return startingWith.negated(actual) };
+Not.prototype.throwing           = function(actual){ return throwing.negated(actual) };
+Not.prototype.true               = function(actual){ return isTrue.negated(actual) };
+Not.prototype.undefined          = function(actual){ return isUndefined.negated(actual) };
+Not.prototype.existing           = function(actual){ return isUndefined(actual); };
+
+Not.prototype.empty              = function(actual){
+    return function(actual){
+        return actual !== '';
+    }
+};
+
+
+var Is = function() {
+    this.not = new Not();
+}
+
+Is.prototype.atLeast        = function(actual) { return atLeast(actual); };
+Is.prototype.atMost         = function(actual) { return atMost(actual); };
+Is.prototype.between        = function(actual) { return between(actual); };
+Is.prototype.containing     = function(actual) { return containing(actual); };
+Is.prototype.endingWith     = function(actual) { return endingWith(actual); };
+Is.prototype.equalTo        = function(actual) { return equalTo(actual); };
+Is.prototype.false          = function(actual) { return isFalse(actual); };
+Is.prototype.falsy          = function(actual) { return falsy(actual); };
+Is.prototype.greaterThan    = function(actual) { return greaterThan(actual); };
+Is.prototype.instanceOf     = function(actual) { return instanceOf(actual); };
+Is.prototype.lessThan       = function(actual) { return lessThan(actual); };
+Is.prototype.NaN            = function(actual) { return isNan(actual); };
+Is.prototype.null           = function(actual) { return isNull(actual); };
+Is.prototype.ofType         = function(actual) { return ofType(actual); };
+Is.prototype.sameAs         = function(actual) { return sameAs(actual); };
+Is.prototype.startingWith   = function(actual) { return startingWith(actual); };
+Is.prototype.throwing       = function(actual) { return throwing(actual); };
+Is.prototype.true           = function(actual) { return isTrue(actual); };
+Is.prototype.undefined      = function(actual) { return isUndefined(actual); };
+Is.prototype.existing       = function(actual) { return isUndefined.negated(actual); };
+
+Is.prototype.Array = function(actual) {
+    return function(actual) {
+        return function () {
+            return Object.prototype.toString.call(actual) === '[object Array]';
+        }
+    }
+}
+
+var assert = assert || {};
 
 assert.that = function (actual) {
-  var is;
-
-  if (arguments.length === 0) {
-    throw new Error('Actual is missing.');
-  }
-
-  is = {};
-  is.not = {};
-
-  is.atLeast = atLeast(actual);
-  is.atMost = atMost(actual);
-  is.between = between(actual);
-  is.containing = containing(actual);
-  is.endingWith = endingWith(actual);
-  is.equalTo = equalTo(actual);
-  is.false = isFalse(actual);
-  is.falsy = falsy(actual);
-  is.greaterThan = greaterThan(actual);
-  is.instanceOf = instanceOf(actual);
-  is.lessThan = lessThan(actual);
-  is.NaN = isNan(actual);
-  is.null = isNull(actual);
-  is.ofType = ofType(actual);
-  is.sameAs = sameAs(actual);
-  is.startingWith = startingWith(actual);
-  is.throwing = throwing(actual);
-  is.true = isTrue(actual);
-  is.undefined = isUndefined(actual);
-
-  is.not.atLeast = atLeast.negated(actual);
-  is.not.atMost = atMost.negated(actual);
-  is.not.between = between.negated(actual);
-  is.not.containing = containing.negated(actual);
-  is.not.endingWith = endingWith.negated(actual);
-  is.not.equalTo = equalTo.negated(actual);
-  is.not.false = isFalse.negated(actual);
-  is.not.falsy = falsy.negated(actual);
-  is.not.greaterThan = greaterThan.negated(actual);
-  is.not.instanceOf = instanceOf.negated(actual);
-  is.not.lessThan = lessThan.negated(actual);
-  is.not.NaN = isNan.negated(actual);
-  is.not.null = isNull.negated(actual);
-  is.not.ofType = ofType.negated(actual);
-  is.not.sameAs = sameAs.negated(actual);
-  is.not.startingWith = startingWith.negated(actual);
-  is.not.throwing = throwing.negated(actual);
-  is.not.true = isTrue.negated(actual);
-  is.not.undefined = isUndefined.negated(actual);
-
-  return { is: is };
+    if (arguments.length === 0) throw new Error('Actual is missing.');
+    return { is: new Is()};
 };
 
 module.exports = assert;

--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -13,6 +13,8 @@ var atLeast = require('./constraints/atLeast'),
     isNan = require('./constraints/nan'),
     isNull = require('./constraints/null'),
     isTrue = require('./constraints/true'),
+    isArray = require('./constraints/array'),
+    isEmpty = require('./constraints/empty'),
     isUndefined = require('./constraints/undefined'),
     lessThan = require('./constraints/lessThan'),
     ofType = require('./constraints/ofType'),
@@ -41,12 +43,7 @@ Not.prototype.throwing           = function(actual){ return throwing.negated(act
 Not.prototype.true               = function(actual){ return isTrue.negated(actual) };
 Not.prototype.undefined          = function(actual){ return isUndefined.negated(actual) };
 Not.prototype.existing           = function(actual){ return isUndefined(actual); };
-
-Not.prototype.empty              = function(actual){
-    return function(actual){
-        return actual !== '';
-    }
-};
+Not.prototype.empty              = function(actual){ return isEmpty.negated(actual); }
 
 
 var Is = function() {
@@ -73,14 +70,8 @@ Is.prototype.throwing       = function(actual) { return throwing(actual); };
 Is.prototype.true           = function(actual) { return isTrue(actual); };
 Is.prototype.undefined      = function(actual) { return isUndefined(actual); };
 Is.prototype.existing       = function(actual) { return isUndefined.negated(actual); };
-
-Is.prototype.array = function(actual) {
-    return function(actual) {
-        return function () {
-            return Object.prototype.toString.call(actual) === '[object Array]';
-        }
-    }
-}
+Is.prototype.array          = function(actual) { return isArray(actual);}
+Is.prototype.empty          = function(actual) { return isEmpty(actual); }
 
 var assert = assert || {};
 

--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -74,7 +74,7 @@ Is.prototype.true           = function(actual) { return isTrue(actual); };
 Is.prototype.undefined      = function(actual) { return isUndefined(actual); };
 Is.prototype.existing       = function(actual) { return isUndefined.negated(actual); };
 
-Is.prototype.Array = function(actual) {
+Is.prototype.array = function(actual) {
     return function(actual) {
         return function () {
             return Object.prototype.toString.call(actual) === '[object Array]';

--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -22,62 +22,65 @@ var atLeast = require('./constraints/atLeast'),
     startingWith = require('./constraints/startingWith'),
     throwing = require('./constraints/throwing');
 
-var Not = function() {}
-Not.prototype.atLeast            = function(actual){ return atLeast.negated(actual) };
-Not.prototype.atMost             = function(actual){ return atMost.negated(actual) };
-Not.prototype.between            = function(actual){ return between.negated(actual) };
-Not.prototype.containing         = function(actual){ return containing.negated(actual) };
-Not.prototype.endingWith         = function(actual){ return endingWith.negated(actual) };
-Not.prototype.equalTo            = function(actual){ return equalTo.negated(actual) };
-Not.prototype.false              = function(actual){ return isFalse.negated(actual) };
-Not.prototype.falsy              = function(actual){ return falsy.negated(actual) };
-Not.prototype.greaterThan        = function(actual){ return greaterThan.negated(actual) };
-Not.prototype.instanceOf         = function(actual){ return instanceOf.negated(actual) };
-Not.prototype.lessThan           = function(actual){ return lessThan.negated(actual) };
-Not.prototype.NaN                = function(actual){ return isNan.negated(actual) };
-Not.prototype.null               = function(actual){ return isNull.negated(actual) };
-Not.prototype.ofType             = function(actual){ return ofType.negated(actual) };
-Not.prototype.sameAs             = function(actual){ return sameAs.negated(actual) };
-Not.prototype.startingWith       = function(actual){ return startingWith.negated(actual) };
-Not.prototype.throwing           = function(actual){ return throwing.negated(actual) };
-Not.prototype.true               = function(actual){ return isTrue.negated(actual) };
-Not.prototype.undefined          = function(actual){ return isUndefined.negated(actual) };
-Not.prototype.existing           = function(actual){ return isUndefined(actual); };
-Not.prototype.empty              = function(actual){ return isEmpty.negated(actual); }
+var Not = function(actual) {
+    this._actual = actual;
+}
+Not.prototype.atLeast            = function(expected){ return atLeast.negated(this._actual)(expected) };
+Not.prototype.atMost             = function(expected){ return atMost.negated(this._actual)(expected) };
+Not.prototype.between            = function(expected){ return between.negated(this._actual)(expected) };
+Not.prototype.containing         = function(expected){ return containing.negated(this._actual)(expected) };
+Not.prototype.endingWith         = function(expected){ return endingWith.negated(this._actual)(expected) };
+Not.prototype.equalTo            = function(expected){ return equalTo.negated(this._actual)(expected) };
+Not.prototype.false              = function(expected){ return isFalse.negated(this._actual)(expected) };
+Not.prototype.falsy              = function(expected){ return falsy.negated(this._actual)(expected) };
+Not.prototype.greaterThan        = function(expected){ return greaterThan.negated(this._actual)(expected) };
+Not.prototype.instanceOf         = function(expected){ return instanceOf.negated(this._actual)(expected) };
+Not.prototype.lessThan           = function(expected){ return lessThan.negated(this._actual)(expected) };
+Not.prototype.NaN                = function(expected){ return isNan.negated(this._actual)(expected) };
+Not.prototype.null               = function(expected){ return isNull.negated(this._actual)(expected) };
+Not.prototype.ofType             = function(expected){ return ofType.negated(this._actual)(expected) };
+Not.prototype.sameAs             = function(expected){ return sameAs.negated(this._actual)(expected) };
+Not.prototype.startingWith       = function(expected){ return startingWith.negated(this._actual)(expected) };
+Not.prototype.throwing           = function(expected){ return throwing.negated(this._actual)(expected) };
+Not.prototype.true               = function(expected){ return isTrue.negated(this._actual)(expected) };
+Not.prototype.undefined          = function(expected){ return isUndefined.negated(this._actual)(expected) };
+Not.prototype.existing           = function(expected){ return isUndefined(this._actual)(expected); };
+Not.prototype.empty              = function(expected){ return isEmpty.negated(this._actual)(expected); }
 
 
-var Is = function() {
-    this.not = new Not();
+var Is = function(actual) {
+    this.actual = actual
+    this.not = new Not(this.actual);
 }
 
-Is.prototype.atLeast        = function(actual) { return atLeast(actual); };
-Is.prototype.atMost         = function(actual) { return atMost(actual); };
-Is.prototype.between        = function(actual) { return between(actual); };
-Is.prototype.containing     = function(actual) { return containing(actual); };
-Is.prototype.endingWith     = function(actual) { return endingWith(actual); };
-Is.prototype.equalTo        = function(actual) { return equalTo(actual); };
-Is.prototype.false          = function(actual) { return isFalse(actual); };
-Is.prototype.falsy          = function(actual) { return falsy(actual); };
-Is.prototype.greaterThan    = function(actual) { return greaterThan(actual); };
-Is.prototype.instanceOf     = function(actual) { return instanceOf(actual); };
-Is.prototype.lessThan       = function(actual) { return lessThan(actual); };
-Is.prototype.NaN            = function(actual) { return isNan(actual); };
-Is.prototype.null           = function(actual) { return isNull(actual); };
-Is.prototype.ofType         = function(actual) { return ofType(actual); };
-Is.prototype.sameAs         = function(actual) { return sameAs(actual); };
-Is.prototype.startingWith   = function(actual) { return startingWith(actual); };
-Is.prototype.throwing       = function(actual) { return throwing(actual); };
-Is.prototype.true           = function(actual) { return isTrue(actual); };
-Is.prototype.undefined      = function(actual) { return isUndefined(actual); };
-Is.prototype.existing       = function(actual) { return isUndefined.negated(actual); };
-Is.prototype.array          = function(actual) { return isArray(actual);}
-Is.prototype.empty          = function(actual) { return isEmpty(actual); }
+Is.prototype.atLeast        = function(expected) { return atLeast(this._actual)(expected); };
+Is.prototype.atMost         = function(expected) { return atMost(this._actual)(expected); };
+Is.prototype.between        = function(expected) { return between(this._actual)(expected); };
+Is.prototype.containing     = function(expected) { return containing(this._actual)(expected); };
+Is.prototype.endingWith     = function(expected) { return endingWith(this._actual)(expected); };
+Is.prototype.equalTo        = function(expected) { return equalTo(this._actual)(expected); };
+Is.prototype.false          = function(expected) { return isFalse(this._actual)(expected); };
+Is.prototype.falsy          = function(expected) { return falsy(this._actual)(expected); };
+Is.prototype.greaterThan    = function(expected) { return greaterThan(this._actual)(expected); };
+Is.prototype.instanceOf     = function(expected) { return instanceOf(this._actual)(expected); };
+Is.prototype.lessThan       = function(expected) { return lessThan(this._actual)(expected); };
+Is.prototype.NaN            = function(expected) { return isNan(this._actual)(expected); };
+Is.prototype.null           = function(expected) { return isNull(this._actual)(expected); };
+Is.prototype.ofType         = function(expected) { return ofType(this._actual)(expected); };
+Is.prototype.sameAs         = function(expected) { return sameAs(this._actual)(expected); };
+Is.prototype.startingWith   = function(expected) { return startingWith(this._actual)(expected); };
+Is.prototype.throwing       = function(expected) { return throwing(this._actual)(expected); };
+Is.prototype.true           = function(expected) { return isTrue(this._actual)(expected); };
+Is.prototype.undefined      = function(expected) { return isUndefined(this._actual)(expected); };
+Is.prototype.existing       = function(expected) { return isUndefined.negated(this._actual)(expected); };
+Is.prototype.array          = function(expected) { return isArray(this._actual)(expected);}
+Is.prototype.empty          = function(expected) { return isEmpty(this._actual)(expected); }
 
 var assert = assert || {};
 
 assert.that = function (actual) {
     if (arguments.length === 0) throw new Error('Actual is missing.');
-    return { is: new Is()};
+    return { is: new Is(actual)};
 };
 
 module.exports = assert;

--- a/lib/constraints/array.js
+++ b/lib/constraints/array.js
@@ -3,8 +3,10 @@ var cmp = require('comparejs');
 var fail = require('../fail');
 
 var isArray = function(actual) {
-    if (Object.prototype.toString.call(actual) === '[object Array]') return true;
-    fail('Expected %s to be an array.', [actual]);
+    return function() {
+        if (Object.prototype.toString.call(actual) === '[object Array]') return true;
+        fail('Expected %s to be an array', [actual]);
+    };
 }
 
 module.exports = isArray;

--- a/lib/constraints/array.js
+++ b/lib/constraints/array.js
@@ -1,0 +1,10 @@
+var cmp = require('comparejs');
+
+var fail = require('../fail');
+
+var isArray = function(actual) {
+    if (Object.prototype.toString.call(actual) === '[object Array]') return true;
+    fail('Expected %s to be an array.', [actual]);
+}
+
+module.exports = isArray;

--- a/lib/constraints/empty.js
+++ b/lib/constraints/empty.js
@@ -3,13 +3,17 @@ var cmp = require('comparejs');
 var fail = require('../fail');
 
 var isEmpty = function(actual) {
-    if (actual === '') return true;
-    fail('Expected %s not to be empty.', [ actual ]);
+    return function() {
+        if (actual === '') return true;
+        fail('Expected %s not to be empty.', [actual]);
+    }
 }
 
 isEmpty.negated = function(actual) {
-    if (actual === '') fail('Expected %s not to be empty.', [ actual ]);
-    return true;
+    return function() {
+        if (actual === '') fail('Expected %s not to be empty.', [actual]);
+        return true;
+    };
 };
 
 module.exports = isEmpty;

--- a/lib/constraints/empty.js
+++ b/lib/constraints/empty.js
@@ -1,0 +1,15 @@
+var cmp = require('comparejs');
+
+var fail = require('../fail');
+
+var isEmpty = function(actual) {
+    if (actual === '') return true;
+    fail('Expected %s not to be empty.', [ actual ]);
+}
+
+isEmpty.negated = function(actual) {
+    if (actual === '') fail('Expected %s not to be empty.', [ actual ]);
+    return true;
+};
+
+module.exports = isEmpty;


### PR DESCRIPTION
As of my issue https://github.com/thenativeweb/assertthat/issues/14 moved assert.that().is & is.not into a prototype object to make it easily extenable