### PR TITLE
[WIP] Added a plugin supported architecure for extensibility

### DIFF
--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -23,7 +23,33 @@ const atLeast = require('./constraints/atLeast'),
       startingWith = require('./constraints/startingWith'),
       throwing = require('./constraints/throwing');
 
-const assert = {};
+const assert = {
+  plugins: []
+};
+
+const validate = function (plugin) {
+  if (typeof plugin.getPropertyName !== 'function') {
+    throw new Error('Plugin Property-Name is missing.');
+  }
+  if (Object.keys(plugin).length < 2) {
+    throw new Error('Plugin does not contain any behaviour.');
+  }
+};
+
+assert.use = function (assertPlugin) {
+  validate(assertPlugin());
+  assert.plugins.push(assertPlugin());
+};
+
+const addPluginKeys = function (actual, keys) {
+  assert.plugins.forEach(plugin => {
+    const pluginLib = {};
+
+    pluginLib.is = {};
+    plugin.addProperties(pluginLib.is, actual);
+    keys[plugin.getPropertyName()] = pluginLib;
+  });
+};
 
 assert.that = function (actual) {
   if (arguments.length === 0) {
@@ -80,7 +106,12 @@ assert.that = function (actual) {
   is.not.true = isTrue.negated(actual);
   is.not.undefined = isUndefined.negated(actual);
 
-  return { is };
+  const keys = {};
+
+  keys.is = is;
+  addPluginKeys(actual, keys);
+
+  return keys;
 };
 
 module.exports = assert;

--- a/test/assertThatTests.js
+++ b/test/assertThatTests.js
@@ -273,4 +273,60 @@ suite('assert', () => {
       });
     });
   });
+
+  suite('plugin support', () => {
+    suite('validate plugin', () => {
+      test('should validate plugin property name', done => {
+        const plugin = function () {
+          const type = {};
+
+          type.foo = 'foo';
+
+          return type;
+        };
+
+        chai.throws(() => assert.use(plugin), 'Plugin Property-Name is missing.');
+        done();
+      });
+
+      test('should validate plugin contains behaviour', done => {
+        const plugin = function () {
+          const type = {};
+
+          type.getPropertyName = function () {
+            return 'type';
+          };
+
+          return type;
+        };
+
+        chai.throws(() => assert.use(plugin), 'Plugin does not contain any behaviour.');
+        done();
+      });
+    });
+
+    suite('plugin injection', () => {
+      test('should add the plugin', done => {
+        const plugin = function () {
+          const typePlugin = {};
+
+          typePlugin.getPropertyName = function () {
+            return 'type';
+          };
+          typePlugin.addProperties = function (is, actual) {
+            is.actual = actual;
+
+            return is;
+          };
+
+          return typePlugin;
+        };
+
+        chai.equal(assert.plugins.length, 0);
+        assert.use(plugin);
+        chai.equal(assert.plugins.length, 1);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Add plugin support for `assertthat`.

For extensibility, i thought of having an extension point for assertthat.

For Example:
    If the user want a specific feature, such as `xml assertion`, which (i think) should not be added in the core, as there are only limited users of this specific feature.
In such cases, it can be used as a plugin.

Currently i have created a plugin for `type-check` which can be used to assert JS types.
(https://github.com/GaneshSPatil/assertthat-type)

PS: as it is the initial implementation of plugin architecture, there will be a lot of things that needs to be changed.
Please take a look at it and let me know what are the things (usability or else code perspective) that needs to be changed.

