### PR TITLE
Assertthat Plugin Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 # OS generated files and folders
 .DS_Store
 npm-debug.log
+.idea

--- a/lib/Extension.js
+++ b/lib/Extension.js
@@ -13,7 +13,7 @@ const Extension = function (extensionName) {
   };
 
   this.addExtension = nestedExtensionName => {
-    this.nextedExtensions[nestedExtensionName] = new Extension(nestedExtensionName);
+    this.nextedExtensions[nestedExtensionName] = this.nextedExtensions[nestedExtensionName] || new Extension(nestedExtensionName);
   };
 
   this.forExtension = nestedExtensionName => this.nextedExtensions[nestedExtensionName];

--- a/lib/Extension.js
+++ b/lib/Extension.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const Extension = function (extensionName) {
+  this.name = extensionName;
+  this.methods = {};
+
+  this.nextedExtensions = {};
+
+  this.addMethod = (name, method) => {
+    this.methods[name] = method;
+
+    return this;
+  };
+
+  this.addExtension = nestedExtensionName => {
+    this.nextedExtensions[nestedExtensionName] = new Extension(nestedExtensionName);
+  };
+
+  this.forExtension = nestedExtensionName => this.nextedExtensions[nestedExtensionName];
+};
+
+module.exports = Extension;

--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -46,13 +46,21 @@ const registerExtension = (extList, extName, extDef, actual) => {
   }
 };
 
-assert.addExtension = extName => {
+const addExtension = extName => {
   extensions[extName] = extensions[extName] || new Extension(extName);
 };
 
-assert.forExtension = extName => extensions[extName];
+const forExtension = extName => extensions[extName];
 
-assert.fail = fail;
+const endpoint = {
+  addExtension,
+  forExtension,
+  fail
+};
+
+assert.use = plugin => {
+  plugin(endpoint);
+};
 
 const addIsExtension = () => {
   assert.addExtension('is');

--- a/lib/assertThat.js
+++ b/lib/assertThat.js
@@ -25,68 +25,105 @@ const atLeast = require('./constraints/atLeast'),
       throwing = require('./constraints/throwing'),
       throwingAsync = require('./constraints/throwingAsync');
 
+const Extension = require('./Extension');
+const fail = require('./fail');
+
 const assert = {};
+const extensions = {};
+
+const registerExtension = (extList, extName, extDef, actual) => {
+  extList[extName] = extList[extName] || {};
+
+  const methods = extDef.methods;
+  const childExtensions = extDef.nextedExtensions;
+
+  for (const methodName in methods) { // eslint-disable-line guard-for-in
+    extList[extName][methodName] = methods[methodName](actual);
+  }
+
+  for (const child in childExtensions) { // eslint-disable-line guard-for-in
+    registerExtension(extList[extName], child, childExtensions[child], actual);
+  }
+};
+
+assert.addExtension = extName => {
+  extensions[extName] = extensions[extName] || new Extension(extName);
+};
+
+assert.forExtension = extName => extensions[extName];
+
+assert.fail = fail;
+
+const addIsExtension = () => {
+  assert.addExtension('is');
+  assert.forExtension('is').addExtension('not');
+
+  assert.forExtension('is').addMethod('atLeast', atLeast).
+    addMethod('atMost', atMost).
+    addMethod('between', between).
+    addMethod('containing', containing).
+    addMethod('containingAnyOf', containingAnyOf).
+    addMethod('containingAllOf', containingAllOf).
+    addMethod('endingWith', endingWith).
+    addMethod('equalTo', equalTo).
+    addMethod('false', isFalse).
+    addMethod('falsy', falsy).
+    addMethod('greaterThan', greaterThan).
+    addMethod('instanceOf', instanceOf).
+    addMethod('lessThan', lessThan).
+    addMethod('matching', matching).
+    addMethod('NaN', isNan).
+    addMethod('null', isNull).
+    addMethod('ofType', ofType).
+    addMethod('sameAs', sameAs).
+    addMethod('sameJsonAs', sameJsonAs).
+    addMethod('startingWith', startingWith).
+    addMethod('throwing', throwing).
+    addMethod('throwingAsync', throwingAsync).
+    addMethod('true', isTrue).
+    addMethod('undefined', isUndefined);
+
+  assert.forExtension('is').forExtension('not').
+    addMethod('atLeast', atLeast.negated).
+    addMethod('atMost', atMost.negated).
+    addMethod('between', between.negated).
+    addMethod('containing', containing.negated).
+    addMethod('containingAnyOf', containingAnyOf.negated).
+    addMethod('containingAllOf', containingAllOf.negated).
+    addMethod('endingWith', endingWith.negated).
+    addMethod('equalTo', equalTo.negated).
+    addMethod('false', isFalse.negated).
+    addMethod('falsy', falsy.negated).
+    addMethod('greaterThan', greaterThan.negated).
+    addMethod('instanceOf', instanceOf.negated).
+    addMethod('lessThan', lessThan.negated).
+    addMethod('matching', matching.negated).
+    addMethod('NaN', isNan.negated).
+    addMethod('null', isNull.negated).
+    addMethod('ofType', ofType.negated).
+    addMethod('sameAs', sameAs.negated).
+    addMethod('sameJsonAs', sameJsonAs.negated).
+    addMethod('startingWith', startingWith.negated).
+    addMethod('throwing', throwing.negated).
+    addMethod('throwingAsync', throwingAsync.negated).
+    addMethod('true', isTrue.negated).
+    addMethod('undefined', isUndefined.negated);
+};
 
 assert.that = function (actual) {
   if (arguments.length === 0) {
     throw new Error('Actual is missing.');
   }
 
-  const is = {
-    not: {}
-  };
+  addIsExtension();
 
-  is.atLeast = atLeast(actual);
-  is.atMost = atMost(actual);
-  is.between = between(actual);
-  is.containing = containing(actual);
-  is.containingAnyOf = containingAnyOf(actual);
-  is.containingAllOf = containingAllOf(actual);
-  is.endingWith = endingWith(actual);
-  is.equalTo = equalTo(actual);
-  is.false = isFalse(actual);
-  is.falsy = falsy(actual);
-  is.greaterThan = greaterThan(actual);
-  is.instanceOf = instanceOf(actual);
-  is.lessThan = lessThan(actual);
-  is.matching = matching(actual);
-  is.NaN = isNan(actual);
-  is.null = isNull(actual);
-  is.ofType = ofType(actual);
-  is.sameAs = sameAs(actual);
-  is.sameJsonAs = sameJsonAs(actual);
-  is.startingWith = startingWith(actual);
-  is.throwing = throwing(actual);
-  is.throwingAsync = throwingAsync(actual);
-  is.true = isTrue(actual);
-  is.undefined = isUndefined(actual);
+  const ext = {};
 
-  is.not.atLeast = atLeast.negated(actual);
-  is.not.atMost = atMost.negated(actual);
-  is.not.between = between.negated(actual);
-  is.not.containing = containing.negated(actual);
-  is.not.containingAnyOf = containingAnyOf.negated(actual);
-  is.not.containingAllOf = containingAllOf.negated(actual);
-  is.not.endingWith = endingWith.negated(actual);
-  is.not.equalTo = equalTo.negated(actual);
-  is.not.false = isFalse.negated(actual);
-  is.not.falsy = falsy.negated(actual);
-  is.not.greaterThan = greaterThan.negated(actual);
-  is.not.instanceOf = instanceOf.negated(actual);
-  is.not.lessThan = lessThan.negated(actual);
-  is.not.matching = matching.negated(actual);
-  is.not.NaN = isNan.negated(actual);
-  is.not.null = isNull.negated(actual);
-  is.not.ofType = ofType.negated(actual);
-  is.not.sameAs = sameAs.negated(actual);
-  is.not.sameJsonAs = sameJsonAs.negated(actual);
-  is.not.startingWith = startingWith.negated(actual);
-  is.not.throwing = throwing.negated(actual);
-  is.not.throwingAsync = throwingAsync.negated(actual);
-  is.not.true = isTrue.negated(actual);
-  is.not.undefined = isUndefined.negated(actual);
+  for (const extName in extensions) { // eslint-disable-line guard-for-in
+    registerExtension(ext, extName, extensions[extName], actual);
+  }
 
-  return { is };
+  return ext;
 };
 
 module.exports = assert;

--- a/test/units/ExtensionTests.js
+++ b/test/units/ExtensionTests.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const chai = require('chai').assert;
+
+const Extension = require('../../lib/Extension');
+
+suite('Extension', () => {
+  test('is a constructor.', done => {
+    const is = new Extension('is');
+
+    chai.typeOf(Extension, 'function');
+    chai.typeOf(is, 'object');
+    done();
+  });
+
+  test('contains the extension name.', done => {
+    const is = new Extension('is');
+
+    chai.equal(is.name, 'is');
+    done();
+  });
+
+  test('contains a method.', done => {
+    const is = new Extension('is');
+
+    chai.deepEqual(is.methods, {});
+
+    const fnName = 'isTrue';
+    const fnDef = arg => arg === true;
+
+    is.addMethod(fnName, fnDef);
+
+    const expected = {};
+
+    expected[fnName] = fnDef;
+    chai.deepEqual(is.methods, expected);
+
+    done();
+  });
+
+  test('contains a nested extension.', done => {
+    const is = new Extension('is');
+
+    chai.deepEqual(is.nextedExtensions, {});
+
+    const extName = 'childExt';
+
+    is.addExtension(extName);
+
+    chai.deepEqual(is.nextedExtensions[extName].methods, {});
+    chai.deepEqual(is.nextedExtensions[extName].nextedExtensions, {});
+    done();
+  });
+
+  test('does not overrides existing nested extension.', done => {
+    const is = new Extension('is');
+
+    chai.deepEqual(is.nextedExtensions, {});
+    const extName = 'childExt';
+    const fnName = 'childExtisTruefn';
+    const fnDef = arg => arg === true;
+
+    is.addExtension(extName);
+    is.forExtension(extName).addMethod(fnName, fnDef);
+
+    const expectedChildExtMethods = {};
+
+    expectedChildExtMethods[fnName] = fnDef;
+    chai.deepEqual(is.nextedExtensions[extName].methods, expectedChildExtMethods);
+
+    is.addExtension(extName);
+
+    chai.deepEqual(is.nextedExtensions[extName].methods, expectedChildExtMethods);
+    done();
+  });
+});

--- a/test/units/assertThatTests.js
+++ b/test/units/assertThatTests.js
@@ -283,4 +283,35 @@ suite('assert', () => {
       });
     });
   });
+
+  suite('extension', () => {
+    test('adds an extension.', done => {
+      const extName = 'a';
+
+      chai.equal(assert.forExtension(extName), null);
+
+      assert.addExtension(extName);
+
+      chai.deepEqual(assert.forExtension(extName).methods, {});
+      chai.deepEqual(assert.forExtension(extName).nextedExtensions, {});
+      done();
+    });
+
+    test('does not override existing extension.', done => {
+      const extName = 'an';
+      const fnName = 'isTrue';
+      const fnDef = arg => arg === true;
+
+      chai.equal(assert.forExtension(extName), null);
+
+      assert.addExtension(extName);
+      assert.forExtension(extName).addMethod(fnName, fnDef);
+
+      const expected = {};
+
+      expected[fnName] = fnDef;
+      chai.deepEqual(assert.forExtension(extName).methods, expected);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Hello @goloroden,

This is an initial draft with for the plugin API extension.

The extension endpoint is documented [here](https://github.com/GaneshSPatil/assertthat/wiki/Asserthat-Plugin-Extension).

I have written an example [assertthat-type](https://github.com/GaneshSPatil/assertthat-type) plugin to demonstrate the use case of the plugin extension.

I would love to hear some feedback on the same.

#### Pending Tasks:
- Some more integration testing around the extension itself.
- Haven't done exception handling. 
    - Example: Accessing extension which hasn't added.
    - Example: Adding duplicate extension/methods by the same plugin.
    - and many more...
- Not sure how to generate `dist` code.



#### Some open questions:
  - The extension exposes `assert.fail` method. (uhh!! any better way to get the handle of assertion failure)?
  - The `addMethod` expects to return a function. The returned function is expected to perform assertions. (As we know, its due to the way `assertthat` has been designed.) Is there any other way to simplify extension endpoint method?

  - The API extension methods which are visible for `assertthat` users too. (can we rename the methods to start with an underscore? Example: `assert._forExtension`).

  - Should we restrict override native methods?

