### PR TITLE
Linking to correct main file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,14 @@
     {
       "name": "Hannes Leutloff",
       "email": "hannes.leutloff@thenativeweb.io"
+    },
+    {
+      "name": "Martin Bories",
+      "email": "martin.bories@protonmail.com"
     }
   ],
   "main": "build/lib/assertThat.js",
-  "types": "assertthat.d.ts",
+  "types": "build/lib/assertthat.d.ts",
   "dependencies": {
     "comparejs": "3.0.0",
     "stringify-object": "3.3.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
       "email": "hannes.leutloff@thenativeweb.io"
     }
   ],
-  "main": "lib/assertThat.js",
+  "main": "build/lib/assertThat.js",
   "types": "assertthat.d.ts",
   "dependencies": {
     "comparejs": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     }
   ],
   "main": "build/lib/assertThat.js",
-  "types": "build/lib/assertthat.d.ts",
+  "types": "build/lib/assertThat.d.ts",
   "dependencies": {
     "comparejs": "3.0.0",
     "stringify-object": "3.3.0"


### PR DESCRIPTION
Background: Currently, the "main"-file is linked to `lib/assertThat.js`; but that file does not exist, only a `lib/assertThat.ts`. This breaks all other modules running on `assertthat@4.0.0`.
Solution: Link to the compiled file (`build/lib/assertThat.js`).