### PR TITLE
fix: dispel values before pretty printing.

### DIFF
--- a/lib/constants/maximumDepth.ts
+++ b/lib/constants/maximumDepth.ts
@@ -1,5 +1,0 @@
-const maximumDepth = 4;
-
-export {
-  maximumDepth
-};

--- a/lib/constants/maximumFormattingDepth.ts
+++ b/lib/constants/maximumFormattingDepth.ts
@@ -1,0 +1,5 @@
+const maximumFormattingDepth = 4;
+
+export {
+  maximumFormattingDepth
+};

--- a/lib/prettyPrint/forArrays/prettyPrintArray.ts
+++ b/lib/prettyPrint/forArrays/prettyPrintArray.ts
@@ -1,5 +1,5 @@
 import { formatNestedArray } from '../utils/formatNestedArray';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 import { prepareSimple } from '../utils/prepareSimple';
 import { prettyPrint } from '../typeAware/prettyPrint';
 
@@ -17,7 +17,7 @@ const prettyPrintArray = function (array: any[], depth = 0): string {
     ));
   }
 
-  if (depth >= maximumDepth) {
+  if (depth >= maximumFormattingDepth) {
     return formatNestedArray`[ ${content} ]`;
   }
 

--- a/lib/prettyPrint/forArrays/prettyPrintArrayDiff.ts
+++ b/lib/prettyPrint/forArrays/prettyPrintArrayDiff.ts
@@ -1,6 +1,6 @@
 import { ArrayDiff } from '../../diffs/forArrays/ArrayDiff';
 import { formatNestedArray } from '../utils/formatNestedArray';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 import { prepareAddition } from '../utils/prepareAddition';
 import { prepareChange } from '../utils/prepareChange';
 import { prepareOmission } from '../utils/prepareOmission';
@@ -49,7 +49,7 @@ const prettyPrintArrayDiff = function (diff: ArrayDiff<any>, depth = 0): string 
     }
   }
 
-  if (depth >= maximumDepth) {
+  if (depth >= maximumFormattingDepth) {
     return formatNestedArray`[ ${content} ]`;
   }
 

--- a/lib/prettyPrint/forMaps/prettyPrintMap.ts
+++ b/lib/prettyPrint/forMaps/prettyPrintMap.ts
@@ -1,5 +1,5 @@
 import { formatNestedArray } from '../utils/formatNestedArray';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 import { prepareSimple } from '../utils/prepareSimple';
 import { prettyPrint } from '../typeAware/prettyPrint';
 
@@ -17,7 +17,7 @@ const prettyPrintMap = function (map: Map<any, any>, depth = 0): string {
     ));
   }
 
-  if (depth >= maximumDepth) {
+  if (depth >= maximumFormattingDepth) {
     return formatNestedArray`Map({ ${content} })`;
   }
 

--- a/lib/prettyPrint/forMaps/prettyPrintMapDiff.ts
+++ b/lib/prettyPrint/forMaps/prettyPrintMapDiff.ts
@@ -1,6 +1,6 @@
 import { formatNestedArray } from '../utils/formatNestedArray';
 import { MapDiff } from '../../diffs/forMaps/MapDiff';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 import { prepareAddition } from '../utils/prepareAddition';
 import { prepareChange } from '../utils/prepareChange';
 import { prepareOmission } from '../utils/prepareOmission';
@@ -41,7 +41,7 @@ const prettyPrintMapDiff = function (diff: MapDiff, depth = 0): string {
     return 'Map({})';
   }
 
-  if (depth >= maximumDepth) {
+  if (depth >= maximumFormattingDepth) {
     return formatNestedArray`Map({ ${content} })`;
   }
 

--- a/lib/prettyPrint/forObjects/prettyPrintObject.ts
+++ b/lib/prettyPrint/forObjects/prettyPrintObject.ts
@@ -1,5 +1,5 @@
 import { formatNestedArray } from '../utils/formatNestedArray';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 import { prepareSimple } from '../utils/prepareSimple';
 import { prettyPrint } from '../typeAware/prettyPrint';
 
@@ -17,7 +17,7 @@ const prettyPrintObject = function (object: object, depth = 0): string {
     ));
   }
 
-  if (depth >= maximumDepth) {
+  if (depth >= maximumFormattingDepth) {
     return formatNestedArray`{ ${content} }`;
   }
 

--- a/lib/prettyPrint/forObjects/prettyPrintObjectDiff.ts
+++ b/lib/prettyPrint/forObjects/prettyPrintObjectDiff.ts
@@ -1,5 +1,5 @@
 import { formatNestedArray } from '../utils/formatNestedArray';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 import { ObjectDiff } from '../../diffs/forObjects/ObjectDiff';
 import { prepareAddition } from '../utils/prepareAddition';
 import { prepareChange } from '../utils/prepareChange';
@@ -41,7 +41,7 @@ const prettyPrintObjectDiff = function (diff: ObjectDiff, depth = 0): string {
     return '{}';
   }
 
-  if (depth >= maximumDepth) {
+  if (depth >= maximumFormattingDepth) {
     return formatNestedArray`{ ${content} }`;
   }
 

--- a/lib/prettyPrint/forSets/prettyPrintSetDiff.ts
+++ b/lib/prettyPrint/forSets/prettyPrintSetDiff.ts
@@ -1,5 +1,5 @@
 import { formatNestedArray } from '../utils/formatNestedArray';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 import { prepareAddition } from '../utils/prepareAddition';
 import { prepareOmission } from '../utils/prepareOmission';
 import { prepareSimple } from '../utils/prepareSimple';
@@ -33,7 +33,7 @@ const prettyPrintSetDiff = function (diff: SetDiff, depth = 0): string {
     return `Set([])`;
   }
 
-  if (depth >= maximumDepth) {
+  if (depth >= maximumFormattingDepth) {
     return formatNestedArray`Set([ ${content} ])`;
   }
 

--- a/lib/prettyPrint/typeAware/prettyPrint.ts
+++ b/lib/prettyPrint/typeAware/prettyPrint.ts
@@ -1,3 +1,4 @@
+import { dispel } from '../../dispel/dispel';
 import { InvalidOperation } from '../../errors';
 import { isArray } from '../../types/isArray';
 import { isBoolean } from '../../types/isBoolean';
@@ -29,47 +30,49 @@ import { prettyPrintSymbol } from '../forSymbols/prettyPrintSymbol';
 import { prettyPrintUndefined } from '../forUndefined/prettyPrintUndefined';
 
 const prettyPrint = function (value: any, depth = 0): string {
+  const dispelledValue = dispel(value);
+
   if (isRecursion(value)) {
-    return prettyPrintRecursion(value);
+    return prettyPrintRecursion(dispelledValue);
   }
   if (isError(value)) {
-    return prettyPrintError(value, depth);
+    return prettyPrintError(dispelledValue, depth);
   }
   if (isSet(value)) {
-    return prettyPrintSet(value, depth);
+    return prettyPrintSet(dispelledValue, depth);
   }
   if (isMap(value)) {
-    return prettyPrintMap(value, depth);
+    return prettyPrintMap(dispelledValue, depth);
   }
   if (isArray(value)) {
-    return prettyPrintArray(value, depth);
+    return prettyPrintArray(dispelledValue, depth);
   }
   if (isResult(value)) {
-    return prettyPrintResult(value, depth);
+    return prettyPrintResult(dispelledValue, depth);
   }
   if (isNumber(value)) {
-    return prettyPrintNumber(value);
+    return prettyPrintNumber(dispelledValue);
   }
   if (isString(value)) {
-    return prettyPrintString(value);
+    return prettyPrintString(dispelledValue);
   }
   if (isBoolean(value)) {
-    return prettyPrintBoolean(value);
+    return prettyPrintBoolean(dispelledValue);
   }
   if (isSymbol(value)) {
-    return prettyPrintSymbol(value);
+    return prettyPrintSymbol(dispelledValue);
   }
   if (isFunction(value)) {
-    return prettyPrintFunction(value);
+    return prettyPrintFunction(dispelledValue);
   }
   if (isObject(value)) {
-    return prettyPrintObject(value, depth);
+    return prettyPrintObject(dispelledValue, depth);
   }
   if (isUndefined(value)) {
-    return prettyPrintUndefined(value);
+    return prettyPrintUndefined(dispelledValue);
   }
   if (isNull(value)) {
-    return prettyPrintNull(value);
+    return prettyPrintNull(dispelledValue);
   }
 
   throw new InvalidOperation('Could not pretty print a value with unknown type.');

--- a/lib/prettyPrint/utils/prepareAddition.ts
+++ b/lib/prettyPrint/utils/prepareAddition.ts
@@ -1,12 +1,12 @@
 import chalk from 'chalk';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 
 const prepareAddition = function (content: string, depth: number): string[] {
   return `${content}`.
     split('\n').
     map(
       (line, index): string => {
-        if (depth >= maximumDepth) {
+        if (depth >= maximumFormattingDepth) {
           return chalk.red(line);
         }
         if (index !== 0) {

--- a/lib/prettyPrint/utils/prepareChange.ts
+++ b/lib/prettyPrint/utils/prepareChange.ts
@@ -1,12 +1,12 @@
 import chalk from 'chalk';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 
 const prepareChange = function (content: string, depth: number): string [] {
   return `${content}`.
     split('\n').
     map(
       (line, index): string => {
-        if (depth >= maximumDepth) {
+        if (depth >= maximumFormattingDepth) {
           return line;
         }
         if (index !== 0) {

--- a/lib/prettyPrint/utils/prepareOmission.ts
+++ b/lib/prettyPrint/utils/prepareOmission.ts
@@ -1,12 +1,12 @@
 import chalk from 'chalk';
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 
 const prepareOmission = function (content: any, depth: number): string[] {
   return `${content}`.
     split('\n').
     map(
       (line, index): string => {
-        if (depth >= maximumDepth) {
+        if (depth >= maximumFormattingDepth) {
           return chalk.green(line);
         }
         if (index !== 0) {

--- a/lib/prettyPrint/utils/prepareSimple.ts
+++ b/lib/prettyPrint/utils/prepareSimple.ts
@@ -1,11 +1,11 @@
-import { maximumDepth } from '../../constants/maximumDepth';
+import { maximumFormattingDepth } from '../../constants/maximumFormattingDepth';
 
 const prepareSimple = function (content: string, depth: number): string[] {
   return `${content}`.
     split('\n').
     map(
       (line): string => {
-        if (depth >= maximumDepth) {
+        if (depth >= maximumFormattingDepth) {
           return line;
         }
 

--- a/test/unit/prettyPrint/recursionTests.ts
+++ b/test/unit/prettyPrint/recursionTests.ts
@@ -2,7 +2,7 @@ import { assert } from '../../../lib';
 import { prettyPrint } from '../../../lib/prettyPrint/typeAware/prettyPrint';
 import { prettyPrintRecursion } from '../../../lib/prettyPrint/forRecursions/prettyPrintRecursion';
 import { recursion } from '../../../lib/types/Recursion';
-import { error, Result, value } from 'defekt';
+import { value } from 'defekt';
 
 suite('prettyPrint', (): void => {
   const recursionSymbol = prettyPrintRecursion(recursion({ recursionPath: '/' }));

--- a/test/unit/prettyPrint/recursionTests.ts
+++ b/test/unit/prettyPrint/recursionTests.ts
@@ -1,0 +1,61 @@
+import { assert } from '../../../lib';
+import { prettyPrint } from '../../../lib/prettyPrint/typeAware/prettyPrint';
+import { prettyPrintRecursion } from '../../../lib/prettyPrint/forRecursions/prettyPrintRecursion';
+import { recursion } from '../../../lib/types/Recursion';
+import { error, Result, value } from 'defekt';
+
+suite('prettyPrint', (): void => {
+  const recursionSymbol = prettyPrintRecursion(recursion({ recursionPath: '/' }));
+  const countRecursionSymbols = (output: string): number => output.split(recursionSymbol).length - 1;
+
+  suite('dispels the value before printing when given a(n)', (): void => {
+    test('array.', async (): Promise<void> => {
+      const someArray: any = [ 1, 3, 3, 7 ];
+
+      someArray.push(someArray, someArray, someArray);
+
+      assert.that(countRecursionSymbols(prettyPrint(someArray))).is.equalTo(3);
+    });
+
+    test('map.', async (): Promise<void> => {
+      const someMap = new Map<string, any>();
+
+      someMap.set('pepps', 2);
+      someMap.set('self', someMap);
+      someMap.set('me', someMap);
+
+      assert.that(countRecursionSymbols(prettyPrint(someMap))).is.equalTo(2);
+    });
+
+    test('object.', async (): Promise<void> => {
+      const someObject = {
+        recursion: undefined as any
+      };
+      const someOtherObject = {
+        recursion: someObject,
+        someDifferentProperty: 1_337
+      };
+
+      someObject.recursion = someOtherObject;
+
+      assert.that(countRecursionSymbols(prettyPrint(someOtherObject))).is.equalTo(1);
+    });
+
+    test('result.', async (): Promise<void> => {
+      const someArray = [ '🦄' ] as any[];
+      const someResult = value(someArray);
+
+      someArray.push(someResult, someResult, someResult, someResult);
+
+      assert.that(countRecursionSymbols(prettyPrint(someResult))).is.equalTo(4);
+    });
+
+    test('set.', async (): Promise<void> => {
+      const someSet = new Set<any>('🐈');
+
+      someSet.add(someSet);
+
+      assert.that(countRecursionSymbols(prettyPrint(someSet))).is.equalTo(1);
+    });
+  });
+});


### PR DESCRIPTION
This resolves #346.

The values are now always dispelled before pretty printing, avoiding infinite loops during printing of the diff.