### PR TITLE
fix: Empty arrays/objects now have size 1.

### DIFF
--- a/lib/size/forArrays/arraySize.ts
+++ b/lib/size/forArrays/arraySize.ts
@@ -2,7 +2,7 @@ import { size } from '../typeAware/size';
 import { sum } from '../../utils/sum';
 
 const arraySize = function <TContent>(value: TContent[]): number {
-  return sum(
+  return 1 + sum(
     value.
       map(
         (item): number => size(item)

--- a/lib/size/forObjects/objectSize.ts
+++ b/lib/size/forObjects/objectSize.ts
@@ -2,7 +2,7 @@ import { size } from '../typeAware/size';
 import { sum } from '../../utils/sum';
 
 const objectSize = function (value: object): number {
-  return sum([ ...Object.values(value) ].map(
+  return 1 + sum([ ...Object.values(value) ].map(
     (item: any): number => size(item)
   ));
 };

--- a/test/unit/assertions/forAny/assertActualIsEqualToExpectedTests.ts
+++ b/test/unit/assertions/forAny/assertActualIsEqualToExpectedTests.ts
@@ -61,4 +61,22 @@ suite('assertActualIsEqualToExpected', (): void => {
       }))
     );
   });
+
+  suite('regression tests', (): void => {
+    test('recognizes empty reference types as difference.', async (): Promise<void> => {
+      const actual = { foo: []};
+      const expected = {};
+
+      assert.that(
+        assertActualIsEqualToExpected(actual, expected)
+      ).is.equalTo(
+        error(new AssertionFailed({
+          message: 'The values are not equal.',
+          actual: prettyPrint(actual),
+          expected: prettyPrint(expected),
+          diff: prettyPrintDiff(compare(actual, expected))
+        }))
+      );
+    });
+  });
 });

--- a/test/unit/comparisons/forObjects/compareObjectsTests.ts
+++ b/test/unit/comparisons/forObjects/compareObjectsTests.ts
@@ -58,4 +58,21 @@ suite('compareObjects', (): void => {
       equal: { bam: 13 }
     }));
   });
+
+  suite('regression tests', (): void => {
+    test('recognizes a property with an empty object as a difference.', async (): Promise<void> => {
+      const actual = { foo: {}};
+      const expected = {};
+
+      const diff = compareObjects(actual, expected);
+
+      assert.that(diff).is.equalTo(objectDiff({
+        cost: 1,
+        additions: { foo: {}},
+        omissions: {},
+        changes: {},
+        equal: {}
+      }));
+    });
+  });
 });


### PR DESCRIPTION
This fixes comparisons where the existence of a property with an empty
array/object in an actual value and the same property missing in the
expected value was not seen as a difference, because the empty
array/object had size 0.

This resolves #397.