### PR TITLE
fix: long strings were claimed equal

### DIFF
--- a/lib/comparisons/forArrays/compareArrays.ts
+++ b/lib/comparisons/forArrays/compareArrays.ts
@@ -50,6 +50,10 @@ const compareArraysLinearly = function <TContent>(
     }
   }
 
+  diff.segments.forEach((segment) => {
+      diff.cost += segment.cost;
+  });
+
   if (diff.cost === 0) {
     return equalDiff({ value: actual });
   }


### PR DESCRIPTION
**What bug was fixed?**
When comparing strings, where the product of the string lengths exceed 10000, they are comapred as char arrays using the **compareArraysLinearly** function. This was leading to the strings beeing claimed equal, despite they aren't.
Example:
_assert.that('A'.repeat(200)).is.equalTo('B'.repeat(200));_ 
should break the test, cause the strings aren't equal, but they are claimed to be equal and the test keeps "green".

**cause**
in lib/comparisons/forArrays/compareArrays.ts:53 there is a check if diff.cost is 0,
but the segment costs weren't summed up, before, so they're always 0.

**fix**
sum up the diff.cost (sum of all segment.cost values) before.
(see lines 53 .. 55)

**tested locally**
- ran _npx roboter test_
- repruduced the change locally in node_modules/assertthat inside of my project and ran my tests again.
  - _assert.that('A'.repeat(200)).is.equalTo('B'.repeat(200));_ breaks the test, like expected
  - _assert.that('A'.repeat(200)).is.equalTo('A'.repeat(200));_ keeps test "green"